### PR TITLE
Experimental: return the Content-Disposition header in Loris

### DIFF
--- a/assets/Makefile
+++ b/assets/Makefile
@@ -3,12 +3,6 @@ include $(ROOT)/makefiles/functions.Makefile
 
 STACK_ROOT 	=
 
-SBT_APPS 	 =
-SBT_SSM_APPS =
-
-SBT_DOCKER_LIBRARIES    =
-SBT_NO_DOCKER_LIBRARIES =
-
 PYTHON_APPS     =
 PYTHON_SSM_APPS =
 LAMBDAS 	    =

--- a/builds/Makefile
+++ b/builds/Makefile
@@ -3,12 +3,6 @@ include $(ROOT)/makefiles/functions.Makefile
 
 STACK_ROOT 	= builds
 
-SBT_APPS 	 =
-SBT_SSM_APPS =
-
-SBT_DOCKER_LIBRARIES    =
-SBT_NO_DOCKER_LIBRARIES =
-
 PYTHON_APPS     =
 PYTHON_SSM_APPS =
 LAMBDAS 	    = notify_pushes

--- a/infrastructure/Makefile
+++ b/infrastructure/Makefile
@@ -3,12 +3,6 @@ include $(ROOT)/makefiles/functions.Makefile
 
 STACK_ROOT = infrastructure
 
-SBT_APPS 	 =
-SBT_SSM_APPS =
-
-SBT_DOCKER_LIBRARIES    =
-SBT_NO_DOCKER_LIBRARIES =
-
 PYTHON_APPS     =
 PYTHON_SSM_APPS =
 LAMBDAS 	    = ecs_ec2_instance_tagger

--- a/loris/Makefile
+++ b/loris/Makefile
@@ -19,3 +19,15 @@ $(ROOT)/loris/loris/requirements.txt: $(ROOT)/loris/loris/requirements.in
 
 loris-run: loris-build
 	$(ROOT)/docker_run.py -- --publish 8888:8888 loris
+
+loris-publish:
+	$(ROOT)/docker_run.py \
+	    --aws --dind -- \
+	    wellcome/publish_service:86 \
+	    	--service_id="loris" \
+	        --project_id="loris" \
+	        --account_id="760097843905" \
+	        --region_id=eu-west-1 \
+	        --namespace=uk.ac.wellcome \
+	        --role_arn="$(DEV_ROLE_ARN)" \
+	        --label=latest

--- a/loris/Makefile
+++ b/loris/Makefile
@@ -3,12 +3,6 @@ include $(ROOT)/makefiles/functions.Makefile
 
 STACK_ROOT 	= loris
 
-SBT_APPS 	 =
-SBT_SSM_APPS =
-
-SBT_DOCKER_LIBRARIES    =
-SBT_NO_DOCKER_LIBRARIES =
-
 PYTHON_APPS     =
 PYTHON_SSM_APPS = loris
 LAMBDAS 	    =

--- a/loris/loris/Dockerfile
+++ b/loris/loris/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 
 
 ENV LORIS_GITHUB_USER loris-imageserver
-ENV LORIS_COMMIT 44f8459f3ff2d549c564631d17cc1e54f5c02066
+ENV LORIS_COMMIT e20ddba48739e1eab8134e51f7493cb2b7bd7c06
 
 COPY requirements.txt /
 COPY install_loris.sh /install_loris.sh

--- a/loris/loris/Dockerfile
+++ b/loris/loris/Dockerfile
@@ -31,13 +31,13 @@ COPY sRGB2014.icc /usr/share/color/icc/colord/sRGB2014.icc
 ENV LORIS_CONF_FILE /opt/loris/etc/loris2.conf
 
 COPY loris2.conf /opt/loris/etc/loris2.conf
+COPY setup_directories.py /loris-$LORIS_COMMIT/bin/setup_directories.py
+RUN python3 /loris-$LORIS_COMMIT/bin/setup_directories.py
+
 COPY loris2.wsgi /var/www/loris2/loris2.wsgi
 COPY uwsgi.ini /etc/uwsgi
 
 COPY wellcome_loris.py /usr/local/lib/python3.5/dist-packages
-
-COPY setup_directories.py /loris-$LORIS_COMMIT/bin/setup_directories.py
-RUN python3 /loris-$LORIS_COMMIT/bin/setup_directories.py
 
 EXPOSE 8888
 

--- a/loris/loris/Dockerfile
+++ b/loris/loris/Dockerfile
@@ -36,6 +36,9 @@ COPY uwsgi.ini /etc/uwsgi
 
 COPY wellcome_loris.py /usr/local/lib/python3.5/dist-packages
 
+COPY setup_directories.py /loris-$LORIS_COMMIT/bin/setup_directories.py
+RUN python3 /loris-$LORIS_COMMIT/bin/setup_directories.py
+
 EXPOSE 8888
 
 CMD ["/usr/bin/uwsgi", "--ini", "/etc/uwsgi/uwsgi.ini"]

--- a/loris/loris/install_loris.sh
+++ b/loris/loris/install_loris.sh
@@ -22,5 +22,6 @@ pip3 install -r /requirements.txt
 echo "*** Installing Loris itself"
 cd "loris-$LORIS_COMMIT"
 python3 setup.py install
+python3 loris/bin/setup_directories.py
 
 apt-get clean

--- a/loris/loris/install_loris.sh
+++ b/loris/loris/install_loris.sh
@@ -22,6 +22,5 @@ pip3 install -r /requirements.txt
 echo "*** Installing Loris itself"
 cd "loris-$LORIS_COMMIT"
 python3 setup.py install
-python3 loris/bin/setup_directories.py
 
 apt-get clean

--- a/loris/loris/loris2.conf
+++ b/loris/loris/loris2.conf
@@ -42,6 +42,12 @@ log_to = 'console'    # 'console'|'file'
 log_level = 'INFO'  # 'DEBUG'|'INFO'|'WARNING'|'ERROR'|'CRITICAL'
 format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 
+# Our Loris logs are sent to CloudWatch, but Loris expects to write logs
+# to a file.  The setup scripts error if this config isn't provided.
+# Remove when https://github.com/loris-imageserver/loris/issues/477
+# is closed.
+log_dir = '/var/log/loris2' # rw-
+
 [resolver]
 impl = 'wellcome_loris.WellcomeTemplateHTTPResolver'
 cache_root = '/mnt/loris/resolver_cache'
@@ -76,3 +82,9 @@ target_formats = ['jpg','png','gif','webp']
 
     [[tif]]
     impl = 'TIF_Transformer'
+
+    # Needed for Loris setup scripts.
+    # Can be removed when https://github.com/loris-imageserver/loris/issues/477
+    # is closed.
+    [[jp2]]
+    tmp_dp = '/tmp/loris'

--- a/loris/loris/loris2.conf
+++ b/loris/loris/loris2.conf
@@ -87,4 +87,9 @@ target_formats = ['jpg','png','gif','webp']
     # Can be removed when https://github.com/loris-imageserver/loris/issues/477
     # is closed.
     [[jp2]]
+    impl = 'KakaduJP2Transformer'
+    kdu_expand = '/usr/local/kdu'
+    kdu_libs = '/usr/lib'
+    mkfifo = '/usr/local/mkfifo'
+    num_threads = 1
     tmp_dp = '/tmp/loris'

--- a/loris/loris/loris2.wsgi
+++ b/loris/loris/loris2.wsgi
@@ -7,4 +7,5 @@ from loris.webapp import create_app
 
 application = create_app(
     debug=False,
-    config_file_path=os.environ['LORIS_CONF_FILE'])
+    config_file_path=os.environ['LORIS_CONF_FILE']
+)

--- a/loris/loris/setup_directories.py
+++ b/loris/loris/setup_directories.py
@@ -6,16 +6,10 @@ import os
 import pathlib
 import sys
 
-sys.path.insert(
-    0, str(pathlib.Path(__file__).parent.parent / "loris")
-)
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "loris"))
 from user_commands import create_default_files_and_directories
 
 
 if __name__ == "__main__":
-    config = ConfigObj(
-        os.environ["LORIS_CONF_FILE"],
-        unrepr=True,
-        interpolation=False
-    )
+    config = ConfigObj(os.environ["LORIS_CONF_FILE"], unrepr=True, interpolation=False)
     create_default_files_and_directories(config)

--- a/loris/loris/setup_directories.py
+++ b/loris/loris/setup_directories.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+
+from configobj import ConfigObj
+import os
+import pathlib
+import sys
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).parent.parent / "loris")
+)
+from user_commands import create_default_files_and_directories
+
+
+if __name__ == "__main__":
+    config = ConfigObj(
+        os.environ["LORIS_CONF_FILE"],
+        unrepr=True,
+        interpolation=False
+    )
+    create_default_files_and_directories(config)

--- a/loris/terraform/terraform.tf
+++ b/loris/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    role_arn = "arn:aws:iam::760097843905:role/developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
 
     bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/loris.tfstate"
@@ -15,7 +15,7 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config {
-    role_arn = "arn:aws:iam::760097843905:role/developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/shared_infra.tfstate"
@@ -30,7 +30,7 @@ provider "aws" {
   version = "1.33.0"
 
   assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
 
@@ -39,6 +39,6 @@ provider "aws" {
   alias  = "us_east_1"
 
   assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }

--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -83,158 +83,6 @@ define publish_service_ssm
 endef
 
 
-# Test an sbt project.
-#
-# Args:c
-#   $1 - Name of the project.
-#
-define sbt_test
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" ";dockerComposeUp;test;dockerComposeStop"
-endef
-
-# Test an sbt project without docker-compose.
-#
-# Args:
-#   $1 - Name of the project.
-#
-define sbt_test_no_docker
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" "test"
-endef
-
-
-# Build an sbt project.
-#
-# Args:
-#   $1 - Name of the project.
-#
-define sbt_build
-	$(ROOT)/docker_run.py --sbt --root -- \
-		wellcome/sbt_wrapper \
-		"project $(1)" ";stage"
-endef
-
-
-# Run docker-compose up.
-#
-# Args:
-#   $1 - Path to the docker-compose file.
-#
-define docker_compose_up
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" "dockerComposeUp"
-endef
-
-
-# Run docker-compose down.
-#
-# Args:
-#   $1 - Path to the docker-compose file.
-#
-define docker_compose_down
-	$(ROOT)/docker_run.py --dind --sbt --root -- \
-		--net host \
-		wellcome/sbt_wrapper \
-		"project $(1)" "dockerComposeDown"
-endef
-
-
-# Define a series of Make tasks (build, test, publish) for a Scala services.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_target_template
-$(eval $(call __sbt_base_docker_template,$(1),$(2)))
-
-$(1)-build:
-	$(call sbt_build,$(1))
-	$(call build_image,$(1),$(2)/Dockerfile)
-
-$(1)-publish: $(1)-build
-	$(call publish_service,$(1))
-endef
-
-
-# Define a series of Make tasks (build, test, publish) for a Scala services.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#	$3 - Stack name
-#   $4 - ECS Base URI
-#   $5 - Registry ID
-#
-define __sbt_ssm_target_template
-$(eval $(call __sbt_base_docker_template,$(1),$(2)))
-
-$(1)-build:
-	$(call sbt_build,$(1))
-	$(call build_image,$(1),$(2)/Dockerfile)
-
-$(1)-publish: $(1)-build
-	$(call publish_service_ssm,$(1),$(3),$(4),$(5))
-endef
-
-
-# Define a series of Make tasks for a Scala libraries that use docker-compose for tests.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_library_docker_template
-$(eval $(call __sbt_base_docker_template,$(1),$(2)))
-
-$(1)-publish:
-	echo "Nothing to do!"
-
-endef
-
-
-# Define a series of Make tasks for a Scala modules that use docker-compose for tests.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_base_docker_template
-$(1)-docker_compose_up:
-	$(call docker_compose_up,$(1))
-
-$(1)-docker_compose_down:
-	$(call docker_compose_down,$(1))
-
-$(1)-test:
-	$(call sbt_test,$(1))
-
-endef
-
-
-# Define a series of Make tasks for a Scala libraries.
-#
-# Args:
-#	$1 - Name of the project in sbt.
-#	$2 - Root of the project's source code.
-#
-define __sbt_library_template
-$(1)-test:
-	$(call sbt_test_no_docker,$(1))
-
-$(1)-publish:
-	echo "Nothing to do!"
-
-endef
-
-
 # Define a series of Make tasks (test, publish) for a Python Lambda.
 #
 # Args:
@@ -294,9 +142,6 @@ endef
 #
 #	$STACK_ROOT             Path to this stack, relative to the repo root
 #
-#	$SBT_APPS               A space delimited list of sbt apps in this stack
-#	$SBT_DOCKER_LIBRARIES   A space delimited list of sbt libraries  in this stack that use docker compose for tests
-#	$SBT_NO_DOCKER_LIBRARIES   A space delimited list of sbt libraries  in this stack that use docker compose for tests
 #	$PYTHON_APPS              A space delimited list of ECS services
 #	$LAMBDAS                A space delimited list of Lambdas in this stack
 #
@@ -313,10 +158,6 @@ define stack_setup
 # It can't actually be written that way because Make is very sensitive to
 # whitespace, but that's the general idea.
 
-$(foreach proj,$(SBT_APPS),$(eval $(call __sbt_target_template,$(proj),$(STACK_ROOT)/$(proj))))
-$(foreach proj,$(SBT_SSM_APPS),$(eval $(call __sbt_ssm_target_template,$(proj),$(STACK_ROOT)/$(proj),$(STACK_ROOT),$(ECR_BASE_URI),$(REGISTRY_ID))))
-$(foreach library,$(SBT_DOCKER_LIBRARIES),$(eval $(call __sbt_library_docker_template,$(library),$(STACK_ROOT)/$(library))))
-$(foreach library,$(SBT_NO_DOCKER_LIBRARIES),$(eval $(call __sbt_library_template,$(library))))
 $(foreach task,$(PYTHON_APPS),$(eval $(call __python_target,$(task),$(STACK_ROOT)/$(task)/Dockerfile)))
 $(foreach task,$(PYTHON_SSM_APPS),$(eval $(call __python_ssm_target,$(task),$(STACK_ROOT)/$(task)/Dockerfile,$(STACK_ROOT),$(ECR_BASE_URI),$(REGISTRY_ID))))
 $(foreach lamb,$(LAMBDAS),$(eval $(call __lambda_target_template,$(lamb),$(STACK_ROOT)/$(lamb))))

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -3,12 +3,6 @@ include $(ROOT)/makefiles/functions.Makefile
 
 STACK_ROOT  = monitoring
 
-SBT_APPS 	 =
-SBT_SSM_APPS =
-
-SBT_DOCKER_LIBRARIES    =
-SBT_NO_DOCKER_LIBRARIES =
-
 PYTHON_APPS     = slack_budget_bot
 PYTHON_SSM_APPS =
 LAMBDAS 	    =   post_to_slack terraform_tracker \

--- a/reporting/Makefile
+++ b/reporting/Makefile
@@ -3,12 +3,6 @@ include $(ROOT)/makefiles/functions.Makefile
 
 STACK_ROOT 	= reporting
 
-SBT_APPS 	 =
-SBT_SSM_APPS =
-
-SBT_DOCKER_LIBRARIES    =
-SBT_NO_DOCKER_LIBRARIES =
-
 PYTHON_APPS     =
 PYTHON_SSM_APPS =
 LAMBDAS 	    = reporting_miro_transformer \

--- a/scripts/download_from_preservica.py
+++ b/scripts/download_from_preservica.py
@@ -101,13 +101,15 @@ def download_from_preservica(preservica_guid):
 
         if (working_dir / entry_title).exists():
             print_message(
-                "··· %s/%s Already downloaded asset:" % (str(i).rjust(len(str(entry_count))), entry_count),
+                "··· %s/%s Already downloaded asset:"
+                % (str(i).rjust(len(str(entry_count))), entry_count),
                 entry_guid,
             )
             continue
         else:
             print_message(
-                "*** %s/%s Fetching asset:" % (str(i).rjust(len(str(entry_count))), entry_count),
+                "*** %s/%s Fetching asset:"
+                % (str(i).rjust(len(str(entry_count))), entry_count),
                 entry_guid,
             )
             download_file(sess, entry_url, path=working_dir / entry_title)

--- a/scripts/download_from_preservica.py
+++ b/scripts/download_from_preservica.py
@@ -60,7 +60,7 @@ def download_from_preservica(preservica_guid):
     sess.auth = HTTPBasicAuth(getpass.getuser(), password)
 
     # Get the initial deliverable unit
-    du_xml = get_xml(sess, url=f"{API_URL}/deliverableUnits/{preservica_guid}")
+    du_xml = get_xml(sess, url="%s/deliverableUnits/%s" % (API_URL, preservica_guid))
     print_message("*** Fetched deliverable XML for:", preservica_guid)
 
     manifestation_links = [
@@ -73,7 +73,7 @@ def download_from_preservica(preservica_guid):
         manifest_guid = manifest_link.split("/")[-1]
         print_message("*** Detected manifestation ID:", manifest_guid)
     else:
-        sys.exit(f"*** Could not detect a manifestation link: {manifestation_links}")
+        sys.exit("*** Could not detect a manifestation link: %s" % manifestation_links)
 
     manifest_xml = get_xml(sess, url=manifest_link)
     print_message("*** Fetched manifestation XML for:", manifest_guid)
@@ -84,7 +84,7 @@ def download_from_preservica(preservica_guid):
     jp2_names = [entry.find("title").text for entry in all_entries]
     common_prefix = os.path.commonprefix(jp2_names).split("_")[0]
     assert len(common_prefix) > 0
-    print(f"*** Using common prefix {common_prefix} for working directory")
+    print("*** Using common prefix %s for working directory" % common_prefix)
 
     exclude_from_git(common_prefix)
 
@@ -101,13 +101,13 @@ def download_from_preservica(preservica_guid):
 
         if (working_dir / entry_title).exists():
             print_message(
-                f"··· {str(i).rjust(len(str(entry_count)))}/{entry_count} Already downloaded asset:",
+                "··· %s/%s Already downloaded asset:" % (str(i).rjust(len(str(entry_count))), entry_count),
                 entry_guid,
             )
             continue
         else:
             print_message(
-                f"*** {str(i).rjust(len(str(entry_count)))}/{entry_count} Fetching asset:",
+                "*** %s/%s Fetching asset:" % (str(i).rjust(len(str(entry_count))), entry_count),
                 entry_guid,
             )
             download_file(sess, entry_url, path=working_dir / entry_title)


### PR DESCRIPTION
This patch deploys https://github.com/loris-imageserver/loris/pull/476, which I wrote in the PyCon UK sprints yesterday.

It means that images downloaded from Loris have marginally more useful filenames which actually contain an ID, rather than just `default.jpg`. An example ID is `s3_L0026000_L0026168.jpg`. They're not perfect, but they're a step in the right direction.

For https://github.com/wellcometrust/wellcomecollection.org/issues/4364

Actually doing what’s described in the ticket – customising them more fully for our use – would need a way to configure Loris to define an (ident) => (filename) mapping, and that was more than I had time for yesterday.