### PR TITLE
Add host header to experience nginx

### DIFF
--- a/nginx/experience.nginx.conf
+++ b/nginx/experience.nginx.conf
@@ -13,6 +13,7 @@ http {
     gzip_proxied    any;
 
     location / {
+      proxy_set_header Host $host;
       proxy_pass http://${APP_HOST}:${APP_PORT}/;
     }
 


### PR DESCRIPTION
[As we use this in checking for preview](https://github.com/wellcomecollection/wellcomecollection.org/blob/master/common/koa-middleware/withPrismicPreviewStatus.js#L6).

The problem being solved by this is that the shareable links (e.g. https://prismic.link/33sOeV4)
1. go to `prismic.io`
1. set a cookie
1. redirect to our page
1. XHR lookup to prismic, which is now authenticated
1. set the reference for the API, and rerender the page

The problem with this is `4.` where you need to have the prismic JS on the page. The only way for us to know whether to do this is if the domain is `preview.wellcomecollection.org`.

We also need to know this on the client and the server as the API ([fetched server side and memoized for performance](https://github.com/wellcomecollection/wellcomecollection.org/blob/master/common/services/prismic/api.js#L32)) so having the cookie is the easiest 1 solution answer.